### PR TITLE
Use inline struct initialization to avoid extra methods.

### DIFF
--- a/focus.c
+++ b/focus.c
@@ -156,9 +156,14 @@ int main(int argc,char *argv[]) {
     
   init_notification();
   init_notification_handler();
-  struct notification_data *d = new_notification_data(title,body,period,duration);
+  struct notification_data d = {
+    .title = title,
+    .body = body,
+    .period = period,
+    .duration = duration
+  };
 
-  add_new_notification(d);
+  add_new_notification(&d);
 
   intiate_tray_icon(title,system_tray_callback);
     

--- a/focus.c
+++ b/focus.c
@@ -156,14 +156,8 @@ int main(int argc,char *argv[]) {
     
   init_notification();
   init_notification_handler();
-  struct notification_data d = {
-    .title = title,
-    .body = body,
-    .period = period,
-    .duration = duration
-  };
 
-  add_new_notification(&d);
+  add_new_notification(title, body, period, duration);
 
   intiate_tray_icon(title,system_tray_callback);
     

--- a/notification_handler.c
+++ b/notification_handler.c
@@ -27,17 +27,6 @@ void init_notification_handler()
   signal(SIGALRM, _notification_handler);
 }
 
-struct notification_data * new_notification_data(char * title,
-                                                 char * body, int period, int duration)
-{
-  struct notification_data * d = malloc(sizeof(struct notification_data));
-  d->title = title;
-  d->body = body;
-  d->period = period;
-  d->duration = duration;
-  return d;
-}
-
 void add_new_notification(struct notification_data* data)
 {
   struct notification_node *t = malloc(sizeof(struct notification_node));

--- a/notification_handler.c
+++ b/notification_handler.c
@@ -11,6 +11,14 @@ void _update_period_list(int time);
 int _get_min_period();
 void _free_list();
 
+struct notification_data{
+    char * title;
+    char * body;
+    int duration;
+    int period;
+    int cperiod;
+};
+
 struct notification_node{
   struct notification_data * notify_data;
   struct notification_node * next;
@@ -27,10 +35,16 @@ void init_notification_handler()
   signal(SIGALRM, _notification_handler);
 }
 
-void add_new_notification(struct notification_data* data)
+void add_new_notification(char * title, char * body,
+                          int period, int duration)
 {
   struct notification_node *t = malloc(sizeof(struct notification_node));
-  t->notify_data = data;
+  t->notify_data = &(struct notification_data) {
+    .title = title,
+    .body = body,
+    .period = period,
+    .duration = duration
+  };
   t->next = head;
   t->notify_data->cperiod =0;
   loginfo("Adding New notification\n");

--- a/notification_handler.h
+++ b/notification_handler.h
@@ -13,8 +13,6 @@ struct notification_data{
 
 void init_notification_handler();
 void add_new_notification(struct notification_data* data);
-struct notification_data * new_notification_data(char * title,
-						 char * body, int period, int duration);
 void pause_notification_handler();
 void resume_notification_handler();
 void uninit_notification_handler();

--- a/notification_handler.h
+++ b/notification_handler.h
@@ -2,17 +2,9 @@
 #define  __FOCUS_NOTIFICATOIN_HANDLER__
 
 
-struct notification_data{
-    char * title;
-    char * body;
-    int duration;
-    int period;
-    int cperiod;
-};
-
-
 void init_notification_handler();
-void add_new_notification(struct notification_data* data);
+void add_new_notification(char * title, char * body,
+                          int period, int duration);
 void pause_notification_handler();
 void resume_notification_handler();
 void uninit_notification_handler();


### PR DESCRIPTION
As is, `new_notification_data` is used to create `notification_data` structs. However, seeing as it's only used in one place and can be replaced with inline struct initialization, I propose the following changes.